### PR TITLE
Update output response schema ref link when creating operations

### DIFF
--- a/src/main/java/org/wso2/soaptorest/OASGenerator.java
+++ b/src/main/java/org/wso2/soaptorest/OASGenerator.java
@@ -97,7 +97,7 @@ public class OASGenerator {
                         Schema<?> outputRefProp = new Schema<>();
                         outputRefProp.setName(SOAPToRESTConstants.OAS_DEFINITIONS_ROOT_ELEMENT_PATH + outputParamQName.getQName().getLocalPart().replaceAll("\\s+", ""));
                         outputRefProp.set$ref(
-                                outputParamQName.getQName().getLocalPart());
+                                SOAPToRESTConstants.OAS_DEFINITIONS_ROOT_ELEMENT_PATH + outputParamQName.getQName().getLocalPart());
                         outputModelSchema.addProperties(outputParamQName.getQName().getLocalPart(), outputRefProp);
                     }
                 }


### PR DESCRIPTION
## Purpose

Add `#/components/schemas/rootElement_` as the prefix to the output response schema.

Under schemas, we are having the request and response schema names with the `rootElement_` prefix. Therefore when creating operations we need to append `#/components/schemas/rootElement_` as the prefix to the output response schema.