### PR TITLE
Fix issue in optional support with complex elements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.wso2</groupId>
     <artifactId>soaptorest</artifactId>
-    <version>1.5</version>
+    <version>1.6</version>
 
     <dependencies>
         <dependency>

--- a/src/main/java/org/wso2/soaptorest/OASGenerator.java
+++ b/src/main/java/org/wso2/soaptorest/OASGenerator.java
@@ -268,8 +268,7 @@ public class OASGenerator {
                 if (innerSchema != null) {
                     parentSchema.addProperties(innerSchema.getName(), innerSchema);
                     // if element is not optional, add it to the required list of parent schema
-                    boolean isRef = xsElement.getRefKey() != null && xsElement.getName() == null;
-                    if (!xsElement.isOptional() && !isRef) {
+                    if (!xsElement.isOptional() && xsElement.getName() != null) {
                         if (parentSchema.getRequired() != null) {
                             parentSchema.getRequired().add(xsElement.getName().getLocalPart());
                         } else {


### PR DESCRIPTION
## Purpose
> When there's a complex element wrapped by a normal element a seperate schema is not added for them in OAS.
Introduced a functionality to find parent schema from the immediate parent element to solve this reference issue.
Fixes wso2/integration-studio/issues/1242