### PR TITLE
Use File to parse path, which honors / in Windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 .idea/
+.classpath
+.project
+.settings/
+/target/

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ Document soapRequestBody;
 ``Document `` contains ```org.w3c.dom.Document``` of the Request message that need to send to the SOAP backend under
 ``soapAction``. This Document contains the message with the placeholders for JSON input
 
+## Run in Command-line
+
+Build the JAR with command ``mvn package``. Then you can generate a YAML output for any WSDL file like this:
+
+```
+java -jar target/soaptorest-1.6-jar-with-dependencies.jar src/test/resources/complex/nested.wsdl MyNestedRestAPI 1.6.2
+```
+
+After the jar file in the command, the 1st parameter (required) is the path to the WSDL file. The 2nd parameter is the REST API title (default WSDL file name), and the 3rd is the version number (default "1.0.0").
+
+
 ## License
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>
                     </descriptorRefs>
+                    <archive>
+                        <manifestEntries>
+                            <Main-Class>org.wso2.soaptorest.SOAPToRESTConverter</Main-Class>
+                        </manifestEntries>
+                    </archive>
                 </configuration>
 
                 <executions>

--- a/src/main/java/org/wso2/soaptorest/WSDLProcessor.java
+++ b/src/main/java/org/wso2/soaptorest/WSDLProcessor.java
@@ -81,9 +81,10 @@ public class WSDLProcessor {
         wsdlReader.setFeature(JAVAX_WSDL_VERBOSE_MODE, false);
         wsdlReader.setFeature(JAVAX_WSDL_IMPORT_DOCUMENTS, false);
         try {
-            String systemId = "";
-            if (path.lastIndexOf(File.separator) > 0) {
-                systemId = path.substring(0, path.lastIndexOf(File.separator));
+            File file = new File(path);
+            String systemId = file.getParent();
+            if (systemId == null) {
+                systemId = "";
             }
             wsdlDefinition = wsdlReader.readWSDL(systemId, WSDLProcessingUtil.getSecuredParsedDocumentFromPath(path, systemId));
             initializeModels(wsdlDefinition, systemId);


### PR DESCRIPTION
## Purpose
Fix 'mvn test' failing in Windows/Cygwin/mingw due to File.separator is \ for Windows JVM.

## Approach
Instead of manually parsing a path using File.separator, let the File class do the job, which honors both / and \ as Windows path separator. For example, "src/test/resources/complex" hard coded in unit tests are properly recognized like Windows path "src\test\resources\complex".