### PR TITLE
Use File to parse path, which honors / in Windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 .idea/
+.classpath
+.project
+.settings/
+/target/

--- a/src/main/java/org/wso2/soaptorest/WSDLProcessor.java
+++ b/src/main/java/org/wso2/soaptorest/WSDLProcessor.java
@@ -81,9 +81,10 @@ public class WSDLProcessor {
         wsdlReader.setFeature(JAVAX_WSDL_VERBOSE_MODE, false);
         wsdlReader.setFeature(JAVAX_WSDL_IMPORT_DOCUMENTS, false);
         try {
-            String systemId = "";
-            if (path.lastIndexOf(File.separator) > 0) {
-                systemId = path.substring(0, path.lastIndexOf(File.separator));
+            File file = new File(path);
+            String systemId = file.getParent();
+            if (systemId == null) {
+                systemId = "";
             }
             wsdlDefinition = wsdlReader.readWSDL(systemId, WSDLProcessingUtil.getSecuredParsedDocumentFromPath(path, systemId));
             initializeModels(wsdlDefinition, systemId);


### PR DESCRIPTION
## Purpose
Fix 'mvn test' failing in Windows/Cygwin/mingw due to File.separator is \ for Windows JVM.

## Approach
Instead of manually parsing a path using File.separator, let the File class do the job, which honors both / and \ as Windows path separator. For example, "src/test/resources/complex" hard coded in unit tests are properly recognized like Windows path "src\test\resources\complex".
